### PR TITLE
Fix `build_all_stats.py`

### DIFF
--- a/data_preparation/build_all_stats.py
+++ b/data_preparation/build_all_stats.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     path_genre_stats = path_cache / "meta_genre_stats.json"
     genre_data = ut.load_cache(path_genre_stats,
                                ut.get_hour_tag_repartition,
-                               args=(args.path_data, list_metadata,
+                               args=(list_metadata,
                                      "meta_genre", ".flac"),
                                ignore_cache=args.ignore_cache)
 
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     path_speaker_cache = path_cache / "speaker_stats.json"
     speaker_data = ut.load_cache(path_speaker_cache,
                                  ut.get_speaker_hours_data,
-                                 args=(args.path_data, list_metadata,
+                                 args=(list_metadata,
                                        ".flac"))
 
     speaker_hours = [x for _, x in speaker_data.items()]

--- a/data_preparation/metadata_completion/utilities.py
+++ b/data_preparation/metadata_completion/utilities.py
@@ -209,7 +209,7 @@ def get_speaker_data(path_dir, list_metadata, pathWav):
     return speakerTalk, multiples
 
 
-def get_speaker_hours_data(path_dir, list_metadata, audio_extension):
+def get_speaker_hours_data(list_metadata, audio_extension):
 
     speakerTalk = {}
     nData = len(list_metadata)
@@ -217,9 +217,8 @@ def get_speaker_hours_data(path_dir, list_metadata, audio_extension):
     bar = progressbar.ProgressBar(maxval=nData)
     bar.start()
 
-    for index, name_metadata in enumerate(list_metadata):
+    for index, pathMetadata in enumerate(list_metadata):
         bar.update(index)
-        pathMetadata = os.path.join(path_dir, name_metadata)
         with open(pathMetadata, 'rb') as file:
             locMetadata = json.load(file)
 
@@ -243,7 +242,7 @@ def get_speaker_hours_data(path_dir, list_metadata, audio_extension):
     return speakerTalk
 
 
-def get_hour_tag_repartition(path_dir, list_metadata, tagName,
+def get_hour_tag_repartition(list_metadata, tagName,
                              audio_extension):
 
     nItems = len(list_metadata)
@@ -252,9 +251,8 @@ def get_hour_tag_repartition(path_dir, list_metadata, tagName,
     bar = progressbar.ProgressBar(maxval=nItems)
     bar.start()
 
-    for index, name_metadata in enumerate(list_metadata):
+    for index, pathMetadata in enumerate(list_metadata):
         bar.update(index)
-        pathMetadata = os.path.join(path_dir, name_metadata)
         with open(pathMetadata, 'rb') as file:
             locMetadata = json.load(file)
 


### PR DESCRIPTION
`list_metadata` already contains full paths, the `os.path.join` seems redundant